### PR TITLE
feat: run migrations when app starts

### DIFF
--- a/backend/Acebook/Program.cs
+++ b/backend/Acebook/Program.cs
@@ -1,6 +1,8 @@
+using acebook.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using Microsoft.EntityFrameworkCore;
 using System.Text;
 using System;
 using DotNetEnv;
@@ -11,6 +13,10 @@ var configBuilder = new ConfigurationBuilder();
 configBuilder.AddEnvironmentVariables();
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Register DbContext
+builder.Services.AddDbContext<AcebookDbContext>();
+
 
 // Add services to the container.
 builder.Services.AddControllers();
@@ -83,6 +89,12 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AcebookDbContext>();
+    db.Database.Migrate(); // This applies any pending migrations
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/backend/Acebook/acebook.csproj
+++ b/backend/Acebook/acebook.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />


### PR DESCRIPTION
The changes to Program.cs cause any pending migrations to run when the app starts. They'll run against whichever database the app has connected to. So if you run the app locally, with no env vars using `dotnet run`, the migrations will run against your local test database. If you do `DATABASE_NAME=acebook_csharp_dev dotnet run` the migrations will run against your local dev database, if you have one. For the deployed app, the migrations will run against the Google Cloud Database. I.e. It _should_ "just work" :)

> There is also a new dependency, which was required to make this work.